### PR TITLE
Red alerts have consistent emoji earmuffs

### DIFF
--- a/views/banners.erb
+++ b/views/banners.erb
@@ -1,7 +1,7 @@
 <% if state.master_broken? %>
 <div class='govuk-grid-row'>
   <h2 class='govuk-heading-xl app-banner app-banner--bad'>
-    🚨 Master is broken
+    🚨 Master is broken 🚨
   </h2>
 </div>
 <% end %>


### PR DESCRIPTION
Now "Master is broken" and "Deploy to production failed" can sit side by side on the dashboard and look nice and consistent