### PR TITLE
Refresh the page every X seconds when specifying `refresh` param

### DIFF
--- a/public/main.js
+++ b/public/main.js
@@ -1,0 +1,13 @@
+try {
+  var urlParams = new URLSearchParams(window.location.search);
+  var refresh = urlParams.get("refresh");
+
+  if (refresh) {
+    var seconds = parseInt(refresh, 10);
+    setTimeout(function() {
+      window.location.reload();
+    }, seconds * 1000);
+  }
+} catch (err) {
+  console.error("Could not set up auto-refresh, error:", err);
+}

--- a/views/index.erb
+++ b/views/index.erb
@@ -10,5 +10,6 @@
   <body>
     <%= erb :banners, locals: { state: state } %>
     <%= erb :environments, locals: { state: state } %>
+    <script src="/main.js" charset="utf-8"></script>
   </body>
 </html>


### PR DESCRIPTION
This is useful when running this on a TV.

Usage (refresh every 60 seconds):

```
open http://localhost:4567/?refresh=60
```

I haven't tested this locally.