### PR TITLE
Bubble "confused" feature flags to the top of the table

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -9,6 +9,7 @@ class MyApp < Sinatra::Base
 
   get '/features' do
     @features = Features.new
+    @sorted_features = @features.all.sort_by { |f| ['confused', 'shipping', 'ok'].index(f.state) }
     erb :features
   end
 end

--- a/views/features.erb
+++ b/views/features.erb
@@ -24,7 +24,7 @@
         </tr>
       </thead>
       <tbody class="govuk-table__body">
-        <% Features.new.all.each do |feature| %>
+        <% @sorted_features.each do |feature| %>
           <tr class="govuk-table__row">
             <th scope="row" class="govuk-table__header apply-feature-header apply-feature-state--<%= feature.state %>"><%= feature.name %></th>
 


### PR DESCRIPTION
The screen isn't big enough to hold all our feature flags and half of
these are out of sight. The correct fix is to remove some flags, but in
the mean time this will help us keep sight of what's in a funny state

<img width="1680" alt="Screenshot 2020-03-02 at 12 40 51" src="https://user-images.githubusercontent.com/642279/75677579-b24bba80-5c83-11ea-8bec-565bd90f0c8b.png">
