### PR TITLE
Filter out builds with nil params

### DIFF
--- a/lib/state.rb
+++ b/lib/state.rb
@@ -31,7 +31,7 @@ class State
   def latest_build_to(environment)
     return qa_builds.first if environment == 'qa'
 
-    release_builds.find do |build|
+    release_builds.select(&:params).find do |build|
       build.params["deploy_#{environment}"] == 'true'
     end
   end
@@ -39,7 +39,7 @@ class State
   def latest_successfull_build_to(environment)
     return latest_successfull_build_to_qa if environment == 'qa'
 
-    release_builds.find do |build|
+    release_builds.select(&:params).find do |build|
       build.succeeded? && build.params["deploy_#{environment}"] == 'true'
     end
   end


### PR DESCRIPTION
We have a weird build in the pipeline that doesn't have any params. This causes the dashboard to fail.

`.select(&:params)` is equivalent to `.select { |b| b.params.present? }`

![Screenshot 2020-05-07 at 16 46 28](https://user-images.githubusercontent.com/1650875/81316619-b630fa00-9083-11ea-9c14-42d0ab469dc5.png)
