### PR TITLE
Remove dotenv/load from Rakefile

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,3 @@
-require 'dotenv/load'
-
 require_relative 'lib/state'
 require_relative 'lib/slack'
 


### PR DESCRIPTION
This breaks in prod, of course. We can use foreman to run rake tasks:

```
heroku run foreman run rake slack:post_deployers_for_today -a apply-ops-dashboard 
```