### PR TITLE
Announce confused feature flags to Slack

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,9 +1,14 @@
 require_relative 'lib/state'
 require_relative 'lib/slack'
+require_relative 'lib/features'
 
 namespace :slack do
   task :post_deployers_for_today do
     state = State.new
     Slack.post_deployers_for_today(state.deployers_for_today)
+  end
+
+  task :post_confused_features do
+    Slack.post_confused_features
   end
 end


### PR DESCRIPTION
This adds a Slack message to announce that one or more features are in a 🥴 confused state - which means they've been enabled on prod but not on staging/sandbox/qa. Confused features make our testing environments unreliable, since they aren't representative of production.

<img width="1121" alt="Screenshot 2020-06-23 at 09 29 30" src="https://user-images.githubusercontent.com/233676/85379805-13014a80-b534-11ea-950a-74840d6c91ce.png">

https://ukgovernmentdfe.slack.com/archives/CN1MCQCHZ/p1592899214037300