### PR TITLE
"Not deployed" vs "inactive" confusion

### DIFF
--- a/lib/feature.rb
+++ b/lib/feature.rb
@@ -16,6 +16,8 @@ class Feature
       'ok'
     elsif [production, sandbox, staging, qa].uniq == %w[inactive]
       'ok'
+    elsif [production, sandbox, staging].include?('not_deployed')
+      'ok'
     elsif qa == 'active' && [production, sandbox, staging].uniq == %w[inactive]
       'shipping'
     else

--- a/lib/feature.rb
+++ b/lib/feature.rb
@@ -1,0 +1,25 @@
+class Feature
+  attr_reader :name, :production, :staging, :sandbox, :qa
+
+  # rubocop:disable Naming/MethodParameterName
+  def initialize(name:, production:, staging:, sandbox:, qa:)
+    @name = name
+    @production = production
+    @sandbox = sandbox
+    @staging = staging
+    @qa = qa
+  end
+  # rubocop:enable Naming/MethodParameterName
+
+  def state
+    if [production, sandbox, staging, qa].uniq == %w[active]
+      'ok'
+    elsif [production, sandbox, staging, qa].uniq == %w[inactive]
+      'ok'
+    elsif qa == 'active' && [production, sandbox, staging].uniq == %w[inactive]
+      'shipping'
+    else
+      'confused'
+    end
+  end
+end

--- a/lib/features.rb
+++ b/lib/features.rb
@@ -1,3 +1,5 @@
+require_relative 'feature'
+
 class Features
   def all
     prod, staging, sandbox, qa = environment_states.values_at :production, :staging, :sandbox, :qa
@@ -62,32 +64,6 @@ class Features
       'active'
     else
       'inactive'
-    end
-  end
-
-  class Feature
-    attr_reader :name, :production, :staging, :sandbox, :qa
-
-    # rubocop:disable Naming/MethodParameterName
-    def initialize(name:, production:, staging:, sandbox:, qa:)
-      @name = name
-      @production = production
-      @sandbox = sandbox
-      @staging = staging
-      @qa = qa
-    end
-    # rubocop:enable Naming/MethodParameterName
-
-    def state
-      if [production, sandbox, staging, qa].uniq == %w[active]
-        'ok'
-      elsif [production, sandbox, staging, qa].uniq == %w[inactive]
-        'ok'
-      elsif qa == 'active' && [production, sandbox, staging].uniq == %w[inactive]
-        'shipping'
-      else
-        'confused'
-      end
     end
   end
 end

--- a/spec/lib/feature_spec.rb
+++ b/spec/lib/feature_spec.rb
@@ -1,0 +1,65 @@
+require_relative '../../lib/feature'
+
+RSpec.describe Feature do
+  describe '#state' do
+    it 'is "ok" when everything is active' do
+      f = Feature.new(
+        name: 'X',
+        production: 'active',
+        staging: 'active',
+        qa: 'active',
+        sandbox: 'active',
+      )
+
+      expect(f.state).to eq 'ok'
+    end
+
+    it 'is "ok" when everything is inactive' do
+      f = Feature.new(
+        name: 'X',
+        production: 'inactive',
+        staging: 'inactive',
+        qa: 'inactive',
+        sandbox: 'inactive',
+      )
+
+      expect(f.state).to eq 'ok'
+    end
+
+    it 'is "confused" when some things are active and some inactive' do
+      f = Feature.new(
+        name: 'X',
+        production: 'active',
+        staging: 'inactive',
+        qa: 'inactive',
+        sandbox: 'inactive',
+      )
+
+      expect(f.state).to eq 'confused'
+    end
+
+    it 'is "shipping" if qa is active and the rest inactive' do
+      f = Feature.new(
+        name: 'X',
+        production: 'inactive',
+        staging: 'inactive',
+        qa: 'active',
+        sandbox: 'inactive',
+      )
+
+      expect(f.state).to eq 'shipping'
+    end
+
+    it 'is "ok" if any of the environments have not been deployed yet' do
+      f = Feature.new(
+        name: 'X',
+        production: 'not_deployed',
+        staging: 'not_deployed',
+        qa: 'inactive',
+        sandbox: 'not_deployed',
+      )
+
+      expect(f.state).to eq 'ok'
+    end
+  end
+end

--- a/spec/lib/features_spec.rb
+++ b/spec/lib/features_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Features do
 
     result = Features.new.all
 
-    expect(result).to all be_a(Features::Feature)
+    expect(result).to all be_a(Feature)
     expect(result.count).to eq 12
   end
 

--- a/spec/lib/slack_spec.rb
+++ b/spec/lib/slack_spec.rb
@@ -1,5 +1,5 @@
 require_relative '../../lib/slack'
-require_relative '../../lib/features'
+require_relative '../../lib/feature'
 
 RSpec.describe Slack do
   around do |ex|
@@ -38,7 +38,7 @@ RSpec.describe Slack do
   describe '.post_confused_features' do
     it 'sends a message when features are confused' do
       confused_features = [
-        Features::Feature.new(name: 'Wonky feature', production: true, staging: false, sandbox: false, qa: false),
+        Feature.new(name: 'Wonky feature', production: true, staging: false, sandbox: false, qa: false),
       ]
 
       slack_request = stub_request(:post, 'https://example.com')


### PR DESCRIPTION
The Slackbot reports that flags which aren't deployed yet are "confused", but they're not — they just haven't been deployed yet:

https://ukgovernmentdfe.slack.com/archives/CN1MCQCHZ/p1594638045293200