### PR TITLE
Send a list of undeployed PRs to Slack

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,7 @@
 require_relative 'lib/state'
 require_relative 'lib/slack'
 require_relative 'lib/features'
+require_relative 'lib/diff'
 
 namespace :slack do
   task :post_deployers_for_today do
@@ -11,5 +12,10 @@ namespace :slack do
   task :post_confused_features do
     confused_features = Features.new.all.select { |f| f.state == 'confused' }
     Slack.post_confused_features(confused_features)
+  end
+
+  task :post_undeployed_prs do
+    prs = Diff.pull_requests_between(state.latest_successfull_build_to('qa').commit_sha, state.latest_successfull_build_to('production').commit_sha)
+    Slack.post_undeployed_prs(prs)
   end
 end

--- a/lib/slack.rb
+++ b/lib/slack.rb
@@ -20,6 +20,16 @@ module Slack
       end
     end
 
+    def post_undeployed_prs(prs)
+      return unless Date.today.on_weekday?
+
+      message = prs.reduce("The following PRs haven’t been deployed yet:\n") do |str, (author, title)|
+        str + "\n- #{title} (#{author})"
+      end
+
+      post(text: message)
+    end
+
   private
 
     def post(text:)

--- a/spec/lib/slack_spec.rb
+++ b/spec/lib/slack_spec.rb
@@ -58,4 +58,20 @@ RSpec.describe Slack do
         .to have_been_made
     end
   end
+
+  describe '.post_undeployed_prs' do
+    it 'sends a message when there are undeployed PRs' do
+      slack_request = stub_request(:post, 'https://example.com')
+
+      undeployed = [
+        ['Alice', 'Fix a bug'],
+        ['Bob', 'Ship a feature'],
+      ]
+
+      Slack.post_undeployed_prs(undeployed)
+
+      expect(slack_request.with(body: hash_including(text: /The following PRs.*?Fix a bug \(Alice\)/m)))
+        .to have_been_made
+    end
+  end
 end


### PR DESCRIPTION
Every day in standup someone asks what's been deployed, and every day we load the Ops dashboard, which takes a while. If the dashboard posted straight to Slack then we'd know without having to visit it.