### PR TITLE
deploy to staging & production from dashboard

### DIFF
--- a/public/azdo.js
+++ b/public/azdo.js
@@ -1,0 +1,178 @@
+const msalConfig = {
+  auth: {
+    authority:
+      "https://login.microsoftonline.com/9c7d9dd3-840c-4b3f-818e-552865082e16",
+    clientId: "6f057dad-8513-4020-8de7-14141bfc1f79",
+  },
+  cache: {
+    cacheLocation: "sessionStorage",
+    storeAuthStateInCookie: true,
+  },
+};
+
+const msalInstance = new Msal.UserAgentApplication(msalConfig);
+
+function onDeployButtonClick(commitSha, deployEnv) {
+  const rowId = `${deployEnv}-deploy`;
+  const progressLabel = getProgressLabelNode();
+  document.getElementById(rowId).querySelector("button").disabled = "disabled";
+  document.getElementById(rowId).appendChild(progressLabel);
+  const inProgressTimer = setInterval(
+    (lbl, initialText) => {
+      if (lbl.innerText !== initialText) lbl.innerText = initialText;
+      else lbl.innerText += "...";
+    }, 1000, progressLabel, progressLabel.innerText);
+
+  getAccount()
+    .then((response) => {
+      if (response.tokenType === "access_token") {
+        triggerBuild(commitSha, response.accessToken, deployEnv);
+      } else {
+        acquireAccessToken().then((token) =>
+          triggerBuild(commitSha, token, deployEnv)
+        );
+      }
+    })
+    .then(() => {
+      clearInterval(inProgressTimer);
+      document.getElementById(rowId).removeChild(progressLabel);
+    })
+    .catch((error) => {
+      logError(error);
+      signIn();
+    });
+}
+
+function getAccount() {
+  const account = msalInstance.getAccount();
+  if (account) {
+    return ssoSilent(account.userName);
+  } else {
+    return signIn();
+  }
+}
+
+function ssoSilent(userName) {
+  const ssoRequest = {
+    loginHint: userName,
+  };
+
+  return msalInstance
+    .ssoSilent(ssoRequest)
+    .then((response) => {
+      console.log("ssoResponse", response);
+      return response;
+    })
+    .catch((error) => {
+      logError(error);
+      signIn();
+    });
+}
+
+function signIn() {
+  const loginRequest = {
+    scopes: ["499b84ac-1321-427f-aa17-267ca6975798/user_impersonation"],
+  };
+
+  return msalInstance
+    .loginPopup(loginRequest)
+    .then((response) => {
+      return response;
+    })
+    .catch(logError);
+}
+
+function acquireAccessToken() {
+  var tokenRequest = {
+    scopes: ["499b84ac-1321-427f-aa17-267ca6975798/user_impersonation"],
+  };
+
+  return msalInstance
+    .acquireTokenSilent(tokenRequest)
+    .then((response) => {
+      return response.accessToken;
+    })
+    .catch((error) => {
+      if (error.name === "InteractionRequiredAuthError") {
+        return msalInstance
+          .acquireTokenPopup(tokenRequest)
+          .then((response) => {
+            return response.accessToken;
+          })
+          .catch(logError);
+      }
+    });
+}
+
+function triggerBuild(commitSha, accessToken, deployEnv) {
+  const headers = new Headers();
+  const tokenBearer = "Bearer " + accessToken;
+  headers.append("Authorization", tokenBearer);
+  headers.append("Accept", "*/*");
+  headers.append("Content-Type", "application/json");
+
+  const deployToProduction = deployEnv === "production";
+
+  const parameters = {
+    deploy_production: deployToProduction,
+    deploy_sandbox: deployToProduction,
+    deploy_staging: !deployToProduction,
+  };
+
+  const requestBody = {
+    definition: {
+      id: 325,
+    },
+    parameters: JSON.stringify(parameters),
+    sourceBranch: "refs/heads/master",
+    sourceVersion: commitSha.trim(),
+  };
+
+  const requestOptions = {
+    method: "POST",
+    headers: headers,
+    body: JSON.stringify(requestBody),
+    redirect: "follow",
+  };
+
+  const azurePipelinesBuildApi =
+    "https://dev.azure.com/dfe-ssp/Become-A-Teacher/_apis/build/builds?api-version=5.1";
+
+  fetch(azurePipelinesBuildApi, requestOptions)
+    .then((response) => {
+      console.log(response);
+      return response.json();
+    })
+    .then((body) => body._links.web.href)
+    .then((link) =>
+      document.getElementById(`${deployEnv}-deploy`).appendChild(getAnchorNode(link, deployEnv))
+    ).catch(logError);
+}
+
+function getAnchorNode(link, env) {
+  var anchor = document.createElement("a");
+  anchor.href = link;
+  anchor.className =
+    "govuk-heading-m app-banner app-banner--small app-banner--progress";
+  anchor.innerText = `🚀 Deployment to ${env} in progress 🚀`;
+  anchor.style.color = "#000";
+
+  return anchor;
+}
+
+function getProgressLabelNode() {
+  var label = document.createElement("label");
+  label.className = "govuk-label";
+  label.innerText = `🚧 Please wait while deployment begins`;
+  label.style.color = "#fff";
+
+  return label;
+}
+
+function signOut() {
+  msalInstance.logout();
+}
+
+function logError(error) {
+  console.log(error);
+}

--- a/views/banners.erb
+++ b/views/banners.erb
@@ -18,7 +18,7 @@
 <% if state.deploying_to_staging? %>
 <div class='govuk-grid-row'>
   <a href='<%= state.latest_build_to('staging').link %>' class='govuk-heading-xl app-banner app-banner--progress'>
-    🐓 <%= state.latest_build_to('staging').deployer_name %> is deploying to staging!
+    🚧 <%= state.latest_build_to('staging').deployer_name %> is deploying to staging!
   </a>
 </div>
 <% end %>
@@ -51,7 +51,7 @@
 <% if state.deploying_to_qa? %>
 <div class='govuk-grid-row' style='margin-top:1px;'>
   <a href='<%= state.latest_build_to('qa').link %>' class='govuk-heading-m app-banner app-banner--small app-banner--progress'>
-    Deploy to QA in progress
+    🚧 Deploy to QA in progress
   </a>
 </div>
 <% end %>

--- a/views/deploy.erb
+++ b/views/deploy.erb
@@ -38,8 +38,12 @@
       <% end %>
     </ol>
 
-    <label class="govuk-label" style='color: #fff;'>Commit to use <a href='https://dfe-ssp.visualstudio.com/Become-A-Teacher/_build?definitionId=325'>for deploy</a>:</label>
-    <input value='<%= state.latest_successfull_build_to('qa').commit_sha %>' class='govuk-input' readonly>
+    <div class="govuk-grid-row" id="staging-deploy">
+        <input value='<%= state.latest_successfull_build_to('qa').commit_sha %>' class='govuk-input govuk-!-width-two-thirds' readonly>
+        <button data-prevent-double-click="true" class="govuk-button" data-module="govuk-button" onclick="onDeployButtonClick('<%= state.latest_successfull_build_to('qa').commit_sha %>', 'staging');">
+           Deploy
+        </button>
+    </div>
   <% end %>
 <% elsif environment == 'production' %>
   <% prs = Diff.pull_requests_between(state.latest_successfull_build_to('staging').commit_sha, state.latest_successfull_build_to('production').commit_sha) %>
@@ -61,7 +65,11 @@
       <% end %>
     </ol>
 
-    <label class="govuk-label" style='color: #fff;'>Commit to use <a href='https://dfe-ssp.visualstudio.com/Become-A-Teacher/_build?definitionId=325'>for deploy</a>:</label>
-    <input value='<%= state.latest_successfull_build_to('staging').commit_sha %>' class='govuk-input' readonly>
+    <div class="govuk-grid-row" id="production-deploy">
+        <input value='<%= state.latest_successfull_build_to('staging').commit_sha %>' class='govuk-input govuk-!-width-two-thirds' readonly>
+        <button data-prevent-double-click="true" class="govuk-button" data-module="govuk-button" onclick="onDeployButtonClick('<%= state.latest_successfull_build_to('staging').commit_sha %>', 'production');">
+           Deploy
+        </button>
+    </div>
   <% end %>
 <% end %>

--- a/views/index.erb
+++ b/views/index.erb
@@ -2,3 +2,5 @@
 <%= erb :environments, locals: { state: state } %>
 <%= erb :deployers, locals: { state: state } %>
 <script src="/main.js" charset="utf-8"></script>
+<script type="text/javascript" src="https://alcdn.msftauth.net/lib/1.3.3/js/msal.min.js" integrity="sha384-36I7QTFSxEfBGkSBpZ3zdySjtmAchWxrUHUFcLzDJVLe4dGnEwnOmp0vRfA1lek+" crossorigin="anonymous"></script>
+<script src="/azdo.js" charset="utf-8"></script>


### PR DESCRIPTION
integrate Azure active directory SSO
to deploy to staging & production from within the dashboard.

https://trello.com/c/pMzSPeFN/2535-spike-deploy-from-apply-ops-dashboard-by-signing-in-with-azure-devops-sso-and-then-triggering-a-deploy-using-client-side-js

The `clientId` mentioned in `azdo.js` is configured in Azure Portal.
scope `499b84ac-1321-427f-aa17-267ca6975798/user_impersonation` refers to Azure DevOps for Azure AD SSO

Before Deploy:
![image](https://user-images.githubusercontent.com/10269434/89551165-8a4c1e80-d802-11ea-98ce-393e77899411.png)

After clicking Deploy Button (button will be disabled and below banner will link to the Azure DevOps build)
![image](https://user-images.githubusercontent.com/10269434/89551017-540e9f00-d802-11ea-8518-27a5c47fdf28.png)


Next Steps:
Post the changelogs to slack channel.