### PR TITLE
donot select same deployers on consecutive days

### DIFF
--- a/clock.rb
+++ b/clock.rb
@@ -4,5 +4,6 @@ require_relative 'lib/notify'
 
 module Clockwork
   every(1.day, 'Notify.inconsistent_feature_flags', at: '12:00') { Notify.inconsistent_feature_flags }
-  every(1.day, 'Daily deployment message', at: ['14:00']) { Notify.daily_deployment_message }
+  every(1.day, 'Notify.daily_deployment_message', at: '14:00') { Notify.daily_deployment_message }
+  every(1.day, 'Populate yesterdays deployer', at: '22:00') { File.write('/app/yesterdays_deployer.json', Deployers.for_today[0].to_json) }
 end

--- a/lib/deployers.rb
+++ b/lib/deployers.rb
@@ -2,7 +2,9 @@ class Deployers
   def self.for_today
     if ENV['DEPLOYERS']
       seed = Time.new.strftime('%-d%m%y').to_i
-      JSON.parse(ENV['DEPLOYERS']).shuffle(random: Random.new(seed))
+      all_deployers = JSON.parse(ENV['DEPLOYERS'])
+      all_deployers.delete(JSON.parse(File.read('yesterdays_deployer.json'))) if File.exist?('yesterdays_deployer.json')
+      all_deployers.shuffle(random: Random.new(seed))
     else
       []
     end

--- a/spec/lib/deployers_spec.rb
+++ b/spec/lib/deployers_spec.rb
@@ -28,5 +28,13 @@ RSpec.describe Deployers do
 
       expect(deployers_for_jan1).not_to eq(deployers_for_jan2)
     end
+
+    it 'does not repeat deployer on consecutive days' do
+      deployer_for_jan1 = Deployers.for_today[0]
+      File.write('yesterdays_deployer.json', deployer_for_jan1.to_json)
+      deployer_for_jan2 = Deployers.for_today[0]
+
+      expect(deployer_for_jan1).not_to eq(deployer_for_jan2)
+    end
   end
 end


### PR DESCRIPTION
populate a `ENV['YESTERDAYS_DEPLOYER']` variable at end of day 
and exclude the person when assigning the deployer the next day.

Simple in-memory implementation until the application is restarted the next time.