### PR TITLE
change DEPLOYERS parameter type to array from string

### DIFF
--- a/azure/template.json
+++ b/azure/template.json
@@ -23,7 +23,7 @@
             "type": "secureString"
         },
         "DEPLOYERS":{
-            "type": "string"
+            "type": "array"
         },
         "SLACK_WEBHOOK_URL":{
             "type": "string"


### PR DESCRIPTION
`DEPLOYERS` parameter is a JSON array