### PR TITLE
use correct path for yesterdays_deployer.json

### DIFF
--- a/clock.rb
+++ b/clock.rb
@@ -5,5 +5,5 @@ require_relative 'lib/notify'
 module Clockwork
   every(1.day, 'Notify.inconsistent_feature_flags', at: '12:00') { Notify.inconsistent_feature_flags }
   every(1.day, 'Notify.daily_deployment_message', at: '14:00') { Notify.daily_deployment_message }
-  every(1.day, 'Populate yesterdays deployer', at: '22:00') { File.write('/app/yesterdays_deployer.json', Deployers.for_today[0].to_json) }
+  every(1.day, 'Populate yesterdays deployer', at: '22:00') { File.write('/app/yesterdays_deployer.json', Deployers.for_today(yesterdays_deployer_file: '/app/yesterdays_deployer.json')[0].to_json) }
 end

--- a/lib/deployers.rb
+++ b/lib/deployers.rb
@@ -1,9 +1,9 @@
 class Deployers
-  def self.for_today
+  def self.for_today(yesterdays_deployer_file: 'yesterdays_deployer.json')
     if ENV['DEPLOYERS']
       seed = Time.new.strftime('%-d%m%y').to_i
       all_deployers = JSON.parse(ENV['DEPLOYERS'])
-      all_deployers.delete(JSON.parse(File.read('yesterdays_deployer.json'))) if File.exist?('yesterdays_deployer.json')
+      all_deployers.delete(JSON.parse(File.read(yesterdays_deployer_file))) if File.exist?(yesterdays_deployer_file)
       all_deployers.shuffle(random: Random.new(seed))
     else
       []


### PR DESCRIPTION
the relative path when running under clockwork is the root of the container and not the /app folder
this means the web app doesn't exclude yesterday's deployer because it is looking for the file relative to its working directory (/app)

Pass `/app/yesterdays_deployer.json` to the `Deployer` class to make sure the clockwork process  and the web app access the same file