### PR TITLE
Message formatting

### DIFF
--- a/lib/slack.rb
+++ b/lib/slack.rb
@@ -26,7 +26,7 @@ module Slack
           message << "- <https://github.com/DFE-Digital/apply-for-teacher-training/pull/#{pr_number}|#{title}> (#{author})"
         end
       else
-        message = ["Good afternoon! Today’s deployer is *<@#{deployers[0]['slackUserId']}>*, but there's **nothing to deploy** - go out and have an ice cream, *<@#{deployers[0]['slackUserId']}>*!"]
+        message = ["Good afternoon! Today’s deployer is *<@#{deployers[0]['slackUserId']}>*, but there's *nothing to deploy* - go out and have an ice cream, *<@#{deployers[0]['slackUserId']}>*!"]
       end
 
       post(text: message.join("\n"), channel: '#twd_apply_tech')

--- a/lib/slack.rb
+++ b/lib/slack.rb
@@ -8,7 +8,7 @@ module Slack
       if confused_features.empty?
         post(text: '✌️ Feature flags are consistent across Production, Staging and Sandbox')
       else
-        message = confused_features.map { |f| "- '#{f.name}'" }.join("\n")
+        message = confused_features.map { |f| "- ‘#{f.name}’" }.join("\n")
 
         post(text: "😬 Uh-oh! The following feature flags are inconsistent across Production, Staging and Sandbox:\n\n#{message}\n\n<https://apply-ops-dashboard.azurewebsites.net/features|:shipitbeaver: Check the feature flags dashboard>")
       end
@@ -26,7 +26,7 @@ module Slack
           message << "- <https://github.com/DFE-Digital/apply-for-teacher-training/pull/#{pr_number}|#{title}> (#{author})"
         end
       else
-        message = ["Good afternoon! Today’s deployer is *<@#{deployers[0]['slackUserId']}>*, but there's *nothing to deploy* - go out and have an ice cream, *<@#{deployers[0]['slackUserId']}>*!"]
+        message = ["Good afternoon! Today’s deployer is *<@#{deployers[0]['slackUserId']}>*, but there’s *nothing to deploy* - go out and have an ice cream, *<@#{deployers[0]['slackUserId']}>*!"]
       end
 
       post(text: message.join("\n"), channel: '#twd_apply_tech')

--- a/spec/lib/slack_spec.rb
+++ b/spec/lib/slack_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Slack do
 
       Slack.daily_deployment_message(deployers, [])
 
-      expect(slack_request.with(body: hash_including(text: "Good afternoon! Today’s deployer is *\u003c@1\u003e*, but there's **nothing to deploy** - go out and have an ice cream, *\u003c@1\u003e*!")))
+      expect(slack_request.with(body: hash_including(text: "Good afternoon! Today’s deployer is *\u003c@1\u003e*, but there's *nothing to deploy* - go out and have an ice cream, *\u003c@1\u003e*!")))
         .to have_been_made
     end
 

--- a/spec/lib/slack_spec.rb
+++ b/spec/lib/slack_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Slack do
 
       Slack.daily_deployment_message(deployers, [])
 
-      expect(slack_request.with(body: hash_including(text: "Good afternoon! Today’s deployer is *\u003c@1\u003e*, but there's *nothing to deploy* - go out and have an ice cream, *\u003c@1\u003e*!")))
+      expect(slack_request.with(body: hash_including(text: "Good afternoon! Today’s deployer is *\u003c@1\u003e*, but there’s *nothing to deploy* - go out and have an ice cream, *\u003c@1\u003e*!")))
         .to have_been_made
     end
 


### PR DESCRIPTION
Not sure if this was intended, but `**nothing to deploy**` looks like it was meant to be emboldened:

<img width="990" alt="Screenshot 2020-09-01 at 09 43 57" src="https://user-images.githubusercontent.com/813383/91828410-025a0880-ec38-11ea-9e19-1f89752b2f63.png">

This PR fixes the Markdown formatting on this message. Also uses smart quotes in a few places they were missing.