### PR TITLE
Fix timestamps on the dashboard

### DIFF
--- a/views/environments.erb
+++ b/views/environments.erb
@@ -8,7 +8,7 @@
 
     <div class='govuk-body govuk-!-font-size-27'>
       last deploy at
-      <%= DateTime.strptime(latest_build.start_time, '%m/%d/%Y %H:%M%p').strftime('%l:%M%P on %A %e %b %Y') %>
+      <%= DateTime.strptime(latest_build.start_time + " UTC", '%m/%d/%Y %H:%M%p %Z').in_time_zone('Europe/London').strftime('%l:%M%P on %A %e %b %Y') %>
       by <%= latest_build.deployer_name %>
     </div>
 


### PR DESCRIPTION
Better late than never!

These were an hour out. Azure doesn't give us timezone information on the timestamps it returns, so they were assumed to be in local time. Add a "UTC" (which is the timezone from Azure) and tell strptime to respect it, then put the parsed time in the correct zone.

**Before**

<img width="882" alt="Screenshot 2020-09-23 at 11 22 19" src="https://user-images.githubusercontent.com/642279/94002838-5ae17900-fd92-11ea-9b98-c1a1de5f956e.png">

**After**
<img width="431" alt="Screenshot 2020-09-23 at 11 46 24" src="https://user-images.githubusercontent.com/642279/94002902-6c2a8580-fd92-11ea-942e-aceaee994845.png">


