### PR TITLE
Change the slack alert channel

### DIFF
--- a/lib/slack.rb
+++ b/lib/slack.rb
@@ -48,7 +48,7 @@ module Slack
 
   private
 
-    def post(text: '', channel: '#twd_apply_tech')
+    def post(text: '', channel: '#twd_find_and_apply_tech')
       payload = {
         username: 'Apply ops dashboard',
         icon_emoji: ':train-beaver:',


### PR DESCRIPTION
Teams have merged – `twd_apply_tech` 👉  `twd_find_and_apply_tech` – need to move the slack alert